### PR TITLE
feat: add colored version string output

### DIFF
--- a/cmd/cmdperf/main.go
+++ b/cmd/cmdperf/main.go
@@ -95,7 +95,17 @@ func main() {
 	)
 
 	if cli.Version {
-		fmt.Printf("cmdperf version %s (built %s)\n", version, buildTime)
+		scheme, err := colorscheme.GetScheme(cli.ColorScheme)
+		if err != nil {
+			scheme = colorscheme.Default()
+		}
+		
+		fmt.Printf("%s %s %s (%s %s)\n",
+			scheme.Command("cmdperf"),
+			scheme.Label("version"),
+			scheme.Value(version),
+			scheme.Label("built"),
+			scheme.Value(buildTime))
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
Enhance the --version output to use the application's color scheme system:
- Apply Command color to "cmdperf"
- Apply Label color to "version" and "built" text
- Apply Value color to version number and build time
- Respects user's --color-scheme setting
- Falls back gracefully if color scheme fails to load

Fixes #7

Generated with [Claude Code](https://claude.ai/code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/miklosn/cmdperf/8)
<!-- Reviewable:end -->
