### PR TITLE
fix: stddev for erroring commands and align separator widths

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -19,10 +19,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1767714506,
+        "lastModified": 1774017633,
         "owner": "cachix",
         "repo": "cachix",
-        "rev": "894c649f0daaa38bbcfb21de64be47dfa7cd0ec9",
+        "rev": "e8be573b417f3daa3dd4cb9052178f848e0c9d1d",
         "type": "github"
       },
       "original": {
@@ -93,10 +93,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1768135262,
+        "lastModified": 1775087534,
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -139,10 +139,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1768935149,
+        "lastModified": 1775585728,
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "18cbede9ff6da05b911c5c4802a397c2686ac8fa",
+        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
         "type": "github"
       },
       "original": {
@@ -246,12 +246,29 @@
         "type": "github"
       }
     },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1769922788,
+        "narHash": "sha256-H3AfG4ObMDTkTJYkd8cz1/RbY9LatN5Mk4UF48VuSXc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "207d15f1a6603226e1e223dc79ac29c7846da32e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1768875095,
+        "lastModified": 1775888245,
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ed142ab1b3a092c4d149245d0c4126a5d7ea00b0",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {
@@ -262,11 +279,14 @@
       }
     },
     "nixpkgs_2": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
       "locked": {
-        "lastModified": 1767052823,
+        "lastModified": 1774287239,
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "538a5124359f0b3d466e1160378c87887e3b51a4",
+        "rev": "fa7125ea7f1ae5430010a6e071f68375a39bd24c",
         "type": "github"
       },
       "original": {

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -6,6 +6,11 @@ inputs:
     url: github:nixos/nixpkgs/nixpkgs-unstable
   devenv:
     url: github:cachix/devenv/v1.11.2
+  git-hooks:
+    url: github:cachix/git-hooks.nix
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
 
 allowUnfree: true
 # If you're willing to use a package that's vulnerable

--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -528,7 +528,7 @@ func calculateStdDev(stats *CommandStats) {
 	count := 0
 
 	for _, result := range stats.RecentResults {
-		if result.Error != nil {
+		if result.TimedOut {
 			continue
 		}
 

--- a/internal/ui/inline.go
+++ b/internal/ui/inline.go
@@ -262,12 +262,13 @@ func (ui *InlineUI) render() {
 	}
 
 	// Always print the header
-	output.WriteString(headerColor("✨ cmdperf - Command Performance Benchmarking ✨\n"))
-	repeatCount := min(termWidth-5, 60)
-	if repeatCount < 1 {
-		repeatCount = 1
+	sepWidth := min(termWidth-5, 100)
+	if sepWidth < 1 {
+		sepWidth = 1
 	}
-	output.WriteString(strings.Repeat("─", repeatCount) + "\n\n")
+
+	output.WriteString(headerColor("✨ cmdperf - Command Performance Benchmarking ✨\n"))
+	output.WriteString(strings.Repeat("─", sepWidth) + "\n\n")
 
 	// For very narrow terminals, hide columns progressively
 	if termWidth < 80 {
@@ -332,11 +333,7 @@ func (ui *InlineUI) render() {
 	// Apply color to the headers
 	headerLine := fmt.Sprintf(headerFormat, headerArgs...)
 	output.WriteString(subheaderColor(headerLine))
-	repeatCount = min(termWidth-5, 100)
-	if repeatCount < 1 {
-		repeatCount = 1
-	}
-	output.WriteString(strings.Repeat("━", repeatCount) + "\n")
+	output.WriteString(strings.Repeat("━", sepWidth) + "\n")
 
 	// Print command progress
 	for _, cmd := range ui.commands {
@@ -483,11 +480,7 @@ func (ui *InlineUI) render() {
 	}
 
 	// Print progress information at the bottom
-	repeatCount = min(termWidth-5, 60)
-	if repeatCount < 1 {
-		repeatCount = 1
-	}
-	output.WriteString(strings.Repeat("─", repeatCount) + "\n")
+	output.WriteString(strings.Repeat("─", sepWidth) + "\n")
 	elapsed := time.Since(ui.startTime).Round(time.Second)
 
 	// Format the ETA string


### PR DESCRIPTION
calculateStdDev skipped all results where Error != nil, so commands that always exit non-zero (e.g. /bin/false) reported StdDev=0 while Mean was still computed. Align stddev with mean by skipping only TimedOut results.

The three horizontal separators in the inline UI used different width caps (60 vs 100), so the top/bottom rules were shorter than the middle rule. Compute a single sepWidth and reuse it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/miklosn/cmdperf/12)
<!-- Reviewable:end -->
